### PR TITLE
Implement Sponsors element styling

### DIFF
--- a/local_packages/football/Resources/Private/Templates/ContentElements/Sponsors.html
+++ b/local_packages/football/Resources/Private/Templates/ContentElements/Sponsors.html
@@ -1,10 +1,14 @@
 <html data-namespace-typo3-fluid="true" xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers">
 
-<h3>{data.header}</h3>
+<div class="py-5 text-center">
+    <h2 class="mb-4">{data.header}</h2>
 
-<f:for each="{sponsors}" as="sponsor">
-    <f:link.typolink parameter="{sponsor.data.url}">
-        <f:image image="{sponsor.image.0}" alt="{sponsor.data.title}" treatIdAsReference="1" />
-    </f:link.typolink>
-</f:for>
+    <div class="d-md-flex justify-content-center">
+        <f:for each="{sponsors}" as="sponsor">
+            <f:link.typolink parameter="{sponsor.data.url}" class="px-3">
+                <f:image image="{sponsor.image.0}" alt="{sponsor.data.title}" width="200" height="auto" treatIdAsReference="1" />
+            </f:link.typolink>
+        </f:for>
+    </div>
+</div>
 </html>


### PR DESCRIPTION
Fixes #45 

**Screenshot:**
<img width="1253" alt="Screenshot 2024-04-11 at 16 46 10" src="https://github.com/TYPO3incubator/surfcamp-team4/assets/1774242/110d37c4-2f35-48e1-8c31-ebe4f11d9d37">
