### PR TITLE
Fix event content overlapping navbar text

### DIFF
--- a/local_packages/football/Resources/Private/Scss/Elements/_events.scss
+++ b/local_packages/football/Resources/Private/Scss/Elements/_events.scss
@@ -12,7 +12,6 @@
         position: absolute;
         bottom: toRem(30);
         left: toRem(20);
-        z-index: 3;
     }
 
     &--title, &--button {

--- a/local_packages/football/Resources/Public/Css/index.css
+++ b/local_packages/football/Resources/Public/Css/index.css
@@ -11795,7 +11795,6 @@ textarea.form-control {
   position: absolute;
   bottom: 1.875rem;
   left: 1.25rem;
-  z-index: 3;
 }
 
 .event--title,


### PR DESCRIPTION
Screenshot of the event boxes below the navbar, now the text inside the events isn't overlapping the navbar content anymore.

![image](https://github.com/user-attachments/assets/b74d9e1d-30d6-4548-b7f7-3b389fa20078)


Fixes #128