### PR TITLE
Adjust too small `maxWInText` constant

### DIFF
--- a/local_packages/football/Configuration/Sets/Football/constants.typoscript
+++ b/local_packages/football/Configuration/Sets/Football/constants.typoscript
@@ -49,7 +49,7 @@ styles.content {
         # cat=content/cTextmedia/b1; type=int+; label= Max Image/Media Width: This indicates that maximum number of pixels (width) a block of media elements inserted as content is allowed to consume
         maxW = 600
         # cat=content/cTextmedia/b2; type=int+; label= Max Image/Media Width (Text): Same as above, but this is the maximum width when text is wrapped around an block of media elements. Default is 50% of the normal Max Media Item Width
-        maxWInText = 300
+        maxWInText = 600
 
         # cat=content/cTextmedia/g1; type=int[0-100]; label= Advanced, Column space: Horizontal distance between media elements in a block in content elements of type "Media & Images". If you change this manually in your CSS, you need to adjust this setting accordingly
         columnSpacing = 10


### PR DESCRIPTION
The `maxWInText` constant copied over from `fluid_styled_content` has a default size of 300, which limited picture elements in that size, even though we stretched them out way further in our layout. This brings it up to par with the column size (so the images aren't like 3000x1000 or something) and causes them to be crisp and sharp again.

Before:

![image](https://github.com/user-attachments/assets/c46478c4-b417-4ae3-b879-b0ee34e87658)

After:

![image](https://github.com/user-attachments/assets/7b88df02-e46d-41dd-9af2-e9cad11b080d)



Fixes #142