### PR TITLE
Configure textmedia `header_layout` field to be more editor friendly

### DIFF
--- a/local_packages/football/Configuration/TsConfig/TCEFORM/tt_content.tsconfig
+++ b/local_packages/football/Configuration/TsConfig/TCEFORM/tt_content.tsconfig
@@ -2,7 +2,19 @@ TCEFORM.tt_content {
     CType.keepItems = game_results,textmedia,cta,hero,sponsors,form_formframework,event_teaser,news_teaser,indexedsearch_pi2,persons_overview
 
     header_layout {
-        keepItems = 2,3,4,100
+        config {
+            default = 2
+        }
+
+        keepItems = 1,2,3,4,5,100
+
+        altLabels {
+             1 = LLL:EXT:football/Resources/Private/Language/locallang_db.tt_content.textmedia.xlf:header_layout.1
+             2 = LLL:EXT:football/Resources/Private/Language/locallang_db.tt_content.textmedia.xlf:header_layout.2
+             3 = LLL:EXT:football/Resources/Private/Language/locallang_db.tt_content.textmedia.xlf:header_layout.3
+             4 = LLL:EXT:football/Resources/Private/Language/locallang_db.tt_content.textmedia.xlf:header_layout.4
+             5 = LLL:EXT:football/Resources/Private/Language/locallang_db.tt_content.textmedia.xlf:header_layout.5
+        }
     }
     imageorient {
         keepItems = 25,26

--- a/local_packages/football/Resources/Private/Language/locallang_db.tt_content.textmedia.xlf
+++ b/local_packages/football/Resources/Private/Language/locallang_db.tt_content.textmedia.xlf
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+    <file source-language="en" datatype="plaintext" original="messages" date="2024-04-07UTC20:18:290">
+        <header>
+            <authorName>Surfcamp-Team4</authorName>
+            <authorEmail>surfcamp@team4.de</authorEmail>
+        </header>
+        <body>
+            <trans-unit id="header_layout.1">
+                <source>Heading 1</source>
+            </trans-unit>
+            <trans-unit id="header_layout.2">
+                <source>Heading 2</source>
+            </trans-unit>
+            <trans-unit id="header_layout.3">
+                <source>Heading 3</source>
+            </trans-unit>
+            <trans-unit id="header_layout.4">
+                <source>Heading 4</source>
+            </trans-unit>
+            <trans-unit id="header_layout.5">
+                <source>Heading 5</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>


### PR DESCRIPTION
This re-adds heading level 1 into the selection, and renames all labels from "Layout n" to say "Heading n" instead to be more explanatory on what the field does:

![image](https://github.com/user-attachments/assets/e39b7138-a538-4d4c-9044-1ca371e81bda)

Fixes #143 