### PR TITLE
Add gap-based spacing to sponsor image listing

### DIFF
--- a/local_packages/football/Resources/Private/Scss/Elements/_import.scss
+++ b/local_packages/football/Resources/Private/Scss/Elements/_import.scss
@@ -6,3 +6,4 @@
 @import "game";
 @import "textmedia";
 @import "events";
+@import "sponsors";

--- a/local_packages/football/Resources/Private/Scss/Elements/_sponsors.scss
+++ b/local_packages/football/Resources/Private/Scss/Elements/_sponsors.scss
@@ -1,0 +1,4 @@
+.sponsor-grid {
+    flex-wrap: wrap;
+    gap: 1rem;
+}

--- a/local_packages/football/Resources/Private/Templates/ContentElements/Sponsors.html
+++ b/local_packages/football/Resources/Private/Templates/ContentElements/Sponsors.html
@@ -3,9 +3,9 @@
 <div class="py-5 text-center">
     <h2 class="mb-4">{data.header}</h2>
 
-    <div class="d-md-flex justify-content-center">
+    <div class="d-md-flex justify-content-center sponsor-grid">
         <f:for each="{sponsors}" as="sponsor">
-            <f:link.typolink parameter="{sponsor.data.url}" class="px-3">
+            <f:link.typolink parameter="{sponsor.data.url}">
                 <f:image image="{sponsor.image.0}" alt="{sponsor.data.title}" width="200" height="auto" treatIdAsReference="1" />
             </f:link.typolink>
         </f:for>

--- a/local_packages/football/Resources/Public/Css/index.css
+++ b/local_packages/football/Resources/Public/Css/index.css
@@ -11851,3 +11851,8 @@ textarea.form-control {
   right: -0.0625rem;
   transform: rotate(-45deg);
 }
+
+.sponsor-grid {
+  flex-wrap: wrap;
+  gap: 1rem;
+}


### PR DESCRIPTION
The errorneous behaviour in this is that the spacing classes were only defined on links, not the actual images. I fixed this with adding wrapping and gaps to the flex container that contains the sponsor images/links, so it works now regardless of content.

Before _(only `img` tags without spacing because no links are set for sponsors)_:

![image](https://github.com/user-attachments/assets/71125d72-674f-4e7b-9ba9-dcbe6684f9de)

After _(gap stylings adds spacing even though the sponsor items don't have links)_:

![image](https://github.com/user-attachments/assets/996cb49c-b32c-400b-ab4e-f8daf844c59f)


Fixes #146 